### PR TITLE
Update Gnome platform runtime version

### DIFF
--- a/org.gnome.Aisleriot.json
+++ b/org.gnome.Aisleriot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Aisleriot",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "sol",
     "rename-appdata-file": "sol.metainfo.xml",


### PR DESCRIPTION
Should fix warning while updating:

```
Info: org.gnome.Platform//40 is end-of-life, with reason:       
   The GNOME 40 runtime is no longer supported as of March 21, 2022. Please ask your application developer to migrate to a supported platform.
Applications using this runtime:
   org.gnome.Aisleriot
```