### PR TITLE
Update to 3.22.34 / runtime 47

### DIFF
--- a/org.gnome.Aisleriot.json
+++ b/org.gnome.Aisleriot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Aisleriot",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "sol",
     "rename-appdata-file": "sol.metainfo.xml",
@@ -36,8 +36,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.gnu.org/gnu/guile/guile-3.0.9.tar.xz",
-                    "sha256": "1a2625ac72b2366e95792f3fe758fd2df775b4044a90a4a9787326e66c0d750d"
+                    "url": "https://ftp.gnu.org/gnu/guile/guile-3.0.10.tar.xz",
+                    "sha256": "bd7168517fd526333446d4f7ab816527925634094fbd37322e17e2b8d8e76388"
                 }
             ],
             "modules":[
@@ -80,8 +80,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/aisleriot.git",
-                    "tag": "3.22.33",
-                    "commit": "92df82480fb7f329256847199451473099eb07d4"
+                    "tag": "3.22.34",
+                    "commit": "5c6a33a4aeefd6cdb4a6bf22aa923f2e655fdeb4"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
*) Update to the latest release (3.22.34)
*) Bump runtime to GNOME 47
*) Use latest stable Guile release