### PR TITLE
Update to latest release and GNOME 48 runtime

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -13,6 +13,15 @@ index 25319eb..6502655 100644
    <id>sol.desktop</id>
    <metadata_license>GPL-3.0+ or GFDL-1.3-only</metadata_license>
    <project_license>GPL-3.0+</project_license>
+@@ -42,7 +42,7 @@
+   </description>
+   <screenshots>
+     <screenshot type="default">
+-      <image type="source">https://wiki.gnome.org/Apps/Aisleriot?action=AttachFile&amp;do=get&amp;target=aisleriot-3.10.png</image>
++      <image type="source">https://gitlab.gnome.org/GNOME/aisleriot/-/raw/da27c5ff79220d7014a5eab817d0218b34f52d7a/data/aisleriot-3.10.png</image>
+     </screenshot>
+   </screenshots>
+   <kudos>
 @@ -50,12 +50,20 @@
      <kudo>ModernToolkit</kudo>
      <kudo>UserDocs</kudo>

--- a/appdata.patch
+++ b/appdata.patch
@@ -13,23 +13,27 @@ index 25319eb..6502655 100644
    <id>sol.desktop</id>
    <metadata_license>GPL-3.0+ or GFDL-1.3-only</metadata_license>
    <project_license>GPL-3.0+</project_license>
-@@ -52,8 +50,15 @@
+@@ -50,12 +50,20 @@
      <kudo>ModernToolkit</kudo>
      <kudo>UserDocs</kudo>
    </kudos>
 +  <releases>
-+    <release version="3.22.33" date="2024-05-18" />
++    <release version="3.22.35" date="2024-01-28" />
 +  </releases>
-+  <content_rating type="oars-1.1" />
    <url type="homepage">https://wiki.gnome.org/Apps/Aisleriot</url>
-+  <url type="vcs-browser">https://gitlab.gnome.org/GNOME/aisleriot</url>
-+  <url type="translate">https://l10n.gnome.org/module/aisleriot/</url>
+   <url type="bugtracker">https://gitlab.gnome.org/GNOME/aisleriot/issues</url>
+   <url type="help">https://help.gnome.org/users/aisleriot/stable/</url>
+   <url type="translate">https://l10n.gnome.org/module/aisleriot/</url>
+   <url type="vcs-browser">https://gitlab.gnome.org/GNOME/aisleriot</url>
    <project_group>GNOME</project_group>
 +  <developer_name>The GNOME Project</developer_name>
++  <developer id="org.gnome">
++    <name>The GNOME Project</name>
++  </developer>
    <translation type="gettext">aisleriot</translation>
 -  <launchable type="desktop-id">sol.desktop</launchable>
 +  <launchable type="desktop-id">org.gnome.Aisleriot.desktop</launchable>
++  <content_rating type="oars-1.1" />
  </component>
 --
 libgit2 1.7.2
-

--- a/appdata.patch
+++ b/appdata.patch
@@ -18,7 +18,7 @@ index 25319eb..6502655 100644
      <kudo>UserDocs</kudo>
    </kudos>
 +  <releases>
-+    <release version="3.22.35" date="2024-01-28" />
++    <release version="3.22.35" date="2025-01-28" />
 +  </releases>
    <url type="homepage">https://wiki.gnome.org/Apps/Aisleriot</url>
    <url type="bugtracker">https://gitlab.gnome.org/GNOME/aisleriot/issues</url>

--- a/org.gnome.Aisleriot.json
+++ b/org.gnome.Aisleriot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Aisleriot",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "sol",
     "rename-appdata-file": "sol.metainfo.xml",
@@ -49,8 +49,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://www.hboehm.info/gc/gc_source/gc-8.2.4.tar.gz",
-                            "sha256": "3d0d3cdbe077403d3106bb40f0cbb563413d6efdbb2a7e1cd6886595dec48fc2"
+                            "url": "https://www.hboehm.info/gc/gc_source/gc-8.2.8.tar.gz",
+                            "sha256": "7649020621cb26325e1fb5c8742590d92fb48ce5c259b502faf7d9fb5dabb160"
                         }
                     ],
                     "modules": [
@@ -78,10 +78,15 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/aisleriot.git",
-                    "tag": "3.22.34",
-                    "commit": "5c6a33a4aeefd6cdb4a6bf22aa923f2e655fdeb4"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/aisleriot/3.22/aisleriot-3.22.35.tar.xz",
+                    "tag": "3.22.35",
+                    "sha256": "01e604cd7009a36c0c5f15424a904e46f8362c306ba5f6bc71fac8a5e7463bf0",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "is-important": true,
+                        "name": "aisleriot"
+                    }
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
Also switch to the tarball (now that it is back) and bump some dependencies.